### PR TITLE
Added a dateTimeShift helper and unit tests

### DIFF
--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -283,11 +283,11 @@ const TemplateParserHelpers = function (request: Request) {
     // Shift a date and time by a specified ammount.
     dateTimeShift: function(options: HelperOptions) {
 
-      let date = options.hash['date'];
-      let format = options.hash['format'];
+      const date = options.hash['date'];
+      const format = options.hash['format'];
 
       // If no date is specified, default to now. If a string is specified, then parse it to a date.
-      let dateToShift = date === undefined ? new Date() : (typeof date === 'string' ? new Date(date) : date);
+      const dateToShift = date === undefined ? new Date() : (typeof date === 'string' ? new Date(date) : date);
 
       if (typeof options.hash['shiftDays'] === 'number') {
         dateToShift.setDate(dateToShift.getDate() + options.hash['shiftDays']);
@@ -315,7 +315,6 @@ const TemplateParserHelpers = function (request: Request) {
           useAdditionalWeekYearTokens: true,
           useAdditionalDayOfYearTokens: true
         }
-        
       );
     },
     // set a variable to be used in the template

--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -289,23 +289,23 @@ const TemplateParserHelpers = function (request: Request) {
       // If no date is specified, default to now. If a string is specified, then parse it to a date.
       const dateToShift = date === undefined ? new Date() : (typeof date === 'string' ? new Date(date) : date);
 
-      if (typeof options.hash['shiftDays'] === 'number') {
-        dateToShift.setDate(dateToShift.getDate() + options.hash['shiftDays']);
+      if (typeof options.hash['days'] === 'number') {
+        dateToShift.setDate(dateToShift.getDate() + options.hash['days']);
       }
-      if (typeof options.hash['shiftMonths']  === 'number') {
-        dateToShift.setMonth(dateToShift.getMonth() + options.hash['shiftMonths']);
+      if (typeof options.hash['months']  === 'number') {
+        dateToShift.setMonth(dateToShift.getMonth() + options.hash['months']);
       }
-      if (typeof options.hash['shiftYears']  === 'number') {
-        dateToShift.setFullYear(dateToShift.getFullYear() + options.hash['shiftYears']);
+      if (typeof options.hash['years']  === 'number') {
+        dateToShift.setFullYear(dateToShift.getFullYear() + options.hash['years']);
       }
-      if (typeof options.hash['shiftHours']  === 'number') {
-        dateToShift.setHours(dateToShift.getHours() + options.hash['shiftHours']);
+      if (typeof options.hash['hours']  === 'number') {
+        dateToShift.setHours(dateToShift.getHours() + options.hash['hours']);
       }
-      if (typeof options.hash['shiftMinutes']  === 'number') {
-        dateToShift.setMinutes(dateToShift.getMinutes() + options.hash['shiftMinutes']);
+      if (typeof options.hash['minutes']  === 'number') {
+        dateToShift.setMinutes(dateToShift.getMinutes() + options.hash['minutes']);
       }
-      if (typeof options.hash['shiftSeconds'] === 'number') {
-        dateToShift.setSeconds(dateToShift.getSeconds() + options.hash['shiftSeconds']);
+      if (typeof options.hash['seconds'] === 'number') {
+        dateToShift.setSeconds(dateToShift.getSeconds() + options.hash['seconds']);
       }
 
       return dateFormat(

--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -282,40 +282,47 @@ const TemplateParserHelpers = function (request: Request) {
     },
     // Shift a date and time by a specified ammount.
     dateTimeShift: function (options: HelperOptions) {
-      const date = options.hash['date'];
-      const format = options.hash['format'];
+      let date: undefined | Date | string = undefined;
+      let format: undefined | string = undefined;
+
+      if (typeof options === 'object' && options.hash) {
+        date = options.hash['date'];
+        format = options.hash['format'];
+      }
 
       // If no date is specified, default to now. If a string is specified, then parse it to a date.
-      const dateToShift =
+      const dateToShift: Date =
         date === undefined
           ? new Date()
           : typeof date === 'string'
           ? new Date(date)
           : date;
 
-      if (typeof options.hash['days'] === 'number') {
-        dateToShift.setDate(dateToShift.getDate() + options.hash['days']);
-      }
-      if (typeof options.hash['months'] === 'number') {
-        dateToShift.setMonth(dateToShift.getMonth() + options.hash['months']);
-      }
-      if (typeof options.hash['years'] === 'number') {
-        dateToShift.setFullYear(
-          dateToShift.getFullYear() + options.hash['years']
-        );
-      }
-      if (typeof options.hash['hours'] === 'number') {
-        dateToShift.setHours(dateToShift.getHours() + options.hash['hours']);
-      }
-      if (typeof options.hash['minutes'] === 'number') {
-        dateToShift.setMinutes(
-          dateToShift.getMinutes() + options.hash['minutes']
-        );
-      }
-      if (typeof options.hash['seconds'] === 'number') {
-        dateToShift.setSeconds(
-          dateToShift.getSeconds() + options.hash['seconds']
-        );
+      if (typeof options === 'object' && options !== null && options.hash) {
+        if (typeof options.hash['days'] === 'number') {
+          dateToShift.setDate(dateToShift.getDate() + options.hash['days']);
+        }
+        if (typeof options.hash['months'] === 'number') {
+          dateToShift.setMonth(dateToShift.getMonth() + options.hash['months']);
+        }
+        if (typeof options.hash['years'] === 'number') {
+          dateToShift.setFullYear(
+            dateToShift.getFullYear() + options.hash['years']
+          );
+        }
+        if (typeof options.hash['hours'] === 'number') {
+          dateToShift.setHours(dateToShift.getHours() + options.hash['hours']);
+        }
+        if (typeof options.hash['minutes'] === 'number') {
+          dateToShift.setMinutes(
+            dateToShift.getMinutes() + options.hash['minutes']
+          );
+        }
+        if (typeof options.hash['seconds'] === 'number') {
+          dateToShift.setSeconds(
+            dateToShift.getSeconds() + options.hash['seconds']
+          );
+        }
       }
 
       return dateFormat(

--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -280,6 +280,44 @@ const TemplateParserHelpers = function (request: Request) {
 
       return toConcat.join('');
     },
+    // Shift a date and time by a specified ammount.
+    dateTimeShift: function(options: HelperOptions) {
+
+      let date = options.hash['date'];
+      let format = options.hash['format'];
+
+      // If no date is specified, default to now. If a string is specified, then parse it to a date.
+      let dateToShift = date === undefined ? new Date() : (typeof date === 'string' ? new Date(date) : date);
+
+      if (typeof options.hash['shiftDays'] === 'number') {
+        dateToShift.setDate(dateToShift.getDate() + options.hash['shiftDays']);
+      }
+      if (typeof options.hash['shiftMonths']  === 'number') {
+        dateToShift.setMonth(dateToShift.getMonth() + options.hash['shiftMonths']);
+      }
+      if (typeof options.hash['shiftYears']  === 'number') {
+        dateToShift.setFullYear(dateToShift.getFullYear() + options.hash['shiftYears']);
+      }
+      if (typeof options.hash['shiftHours']  === 'number') {
+        dateToShift.setHours(dateToShift.getHours() + options.hash['shiftHours']);
+      }
+      if (typeof options.hash['shiftMinutes']  === 'number') {
+        dateToShift.setMinutes(dateToShift.getMinutes() + options.hash['shiftMinutes']);
+      }
+      if (typeof options.hash['shiftSeconds'] === 'number') {
+        dateToShift.setSeconds(dateToShift.getSeconds() + options.hash['shiftSeconds']);
+      }
+
+      return dateFormat(
+        dateToShift,
+        typeof format === 'string' ? format : "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+        {
+          useAdditionalWeekYearTokens: true,
+          useAdditionalDayOfYearTokens: true
+        }
+        
+      );
+    },
     // set a variable to be used in the template
     setVar: function (
       name: string,

--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -281,31 +281,41 @@ const TemplateParserHelpers = function (request: Request) {
       return toConcat.join('');
     },
     // Shift a date and time by a specified ammount.
-    dateTimeShift: function(options: HelperOptions) {
-
+    dateTimeShift: function (options: HelperOptions) {
       const date = options.hash['date'];
       const format = options.hash['format'];
 
       // If no date is specified, default to now. If a string is specified, then parse it to a date.
-      const dateToShift = date === undefined ? new Date() : (typeof date === 'string' ? new Date(date) : date);
+      const dateToShift =
+        date === undefined
+          ? new Date()
+          : typeof date === 'string'
+          ? new Date(date)
+          : date;
 
       if (typeof options.hash['days'] === 'number') {
         dateToShift.setDate(dateToShift.getDate() + options.hash['days']);
       }
-      if (typeof options.hash['months']  === 'number') {
+      if (typeof options.hash['months'] === 'number') {
         dateToShift.setMonth(dateToShift.getMonth() + options.hash['months']);
       }
-      if (typeof options.hash['years']  === 'number') {
-        dateToShift.setFullYear(dateToShift.getFullYear() + options.hash['years']);
+      if (typeof options.hash['years'] === 'number') {
+        dateToShift.setFullYear(
+          dateToShift.getFullYear() + options.hash['years']
+        );
       }
-      if (typeof options.hash['hours']  === 'number') {
+      if (typeof options.hash['hours'] === 'number') {
         dateToShift.setHours(dateToShift.getHours() + options.hash['hours']);
       }
-      if (typeof options.hash['minutes']  === 'number') {
-        dateToShift.setMinutes(dateToShift.getMinutes() + options.hash['minutes']);
+      if (typeof options.hash['minutes'] === 'number') {
+        dateToShift.setMinutes(
+          dateToShift.getMinutes() + options.hash['minutes']
+        );
       }
       if (typeof options.hash['seconds'] === 'number') {
-        dateToShift.setSeconds(dateToShift.getSeconds() + options.hash['seconds']);
+        dateToShift.setSeconds(
+          dateToShift.getSeconds() + options.hash['seconds']
+        );
       }
 
       return dateFormat(

--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -282,8 +282,8 @@ const TemplateParserHelpers = function (request: Request) {
     },
     // Shift a date and time by a specified ammount.
     dateTimeShift: function (options: HelperOptions) {
-      let date: undefined | Date | string = undefined;
-      let format: undefined | string = undefined;
+      let date: undefined | Date | string;
+      let format: undefined | string;
 
       if (typeof options === 'object' && options.hash) {
         date = options.hash['date'];

--- a/test/template-parser.spec.ts
+++ b/test/template-parser.spec.ts
@@ -102,22 +102,22 @@ describe('Template parser', () => {
   describe('Helper: dateTimeShift', () => {
     it('Should return a date shifted the specified amount of days from now.', ()=>{
       const parseResult = TemplateParser(
-        "{{dateTimeShift shiftDays=2}}",
+        '{{dateTimeShift shiftDays=2}}',
         {} as any
-      )
+      );
 
-      let date = new Date();
+      const date = new Date();
       date.setDate(date.getDate() + 2);
       // As our reference date here may differ slightly from the one interally used in the helper, it's more reliable to just compare the date/time with the seconds (and lower) excluded.
-      var dateString = dateFormat(date, "yyyy-MM-dd'T'HH:mm");
-      expect(parseResult).to.match(new RegExp(dateString + ".*"));
+      const dateString = dateFormat(date, "yyyy-MM-dd'T'HH:mm");
+      expect(parseResult).to.match(new RegExp(dateString + '.*'));
     });
 
     it('Should return a date shifted by the requested amount from a specified start date.', ()=>{
       const parseResult = TemplateParser(
         "{{dateTimeShift date='2021-02-01' shiftDays=2 shiftMonths=4}}",
         {} as any
-      )
+      );
 
       expect(parseResult).to.match(/2021-06-03.*/);
     });
@@ -126,7 +126,7 @@ describe('Template parser', () => {
       const parseResult = TemplateParser(
         "{{dateTimeShift date='2021-02-01' format='yyyy-MM-dd' shiftDays=2 shiftMonths=4}}",
         {} as any
-      )
+      );
 
       expect(parseResult).to.equals('2021-06-03');
     });
@@ -135,11 +135,11 @@ describe('Template parser', () => {
       const parseResult = TemplateParser(
         "{{dateTimeShift date='2021-02-01T10:45:00' format=\"yyyy-MM-dd'T'HH:mm:ss\" shiftDays=8 shiftMonths=3 shiftHours=1 shiftMinutes=2 shiftSeconds=3}}",
         {} as any
-      )
+      );
 
       expect(parseResult).to.equals('2021-05-09T11:47:03');
     });
-  })
+  });
 
   describe('Helper: someOf', () => {
     it('should return one element', () => {
@@ -147,6 +147,7 @@ describe('Template parser', () => {
         "{{someOf (array 'value1' 'value2' 'value3' 'value4' 'value5' 'value6') 1 1}}",
         {} as any
       );
+
       const count = (parseResult.match(/value/g) || []).length;
       expect(count).to.equal(1);
     });
@@ -156,6 +157,7 @@ describe('Template parser', () => {
         "{{someOf (array 'value1' 'value2' 'value3' 'value4' 'value5' 'value6') 1 3}}",
         {} as any
       );
+
       const countItems = (parseResult.match(/value/g) || []).length;
       expect(countItems).is.least(1);
       expect(countItems).is.most(3);

--- a/test/template-parser.spec.ts
+++ b/test/template-parser.spec.ts
@@ -100,6 +100,15 @@ describe('Template parser', () => {
   });
 
   describe('Helper: dateTimeShift', () => {
+    it('Should not throw an error when passed with invalid parameters.', () => {
+      const parseResult = TemplateParser('{{dateTimeShift 1}}', {} as any);
+
+      // When invalid parameters are passed, the default should just be to return the current date with no shift.
+      const date = new Date();
+      const dateString = dateFormat(date, "yyyy-MM-dd'T'HH:mm");
+      expect(parseResult).to.match(new RegExp(dateString + '.*'));
+    });
+
     it('Should return a date shifted the specified amount of days from now.', () => {
       const parseResult = TemplateParser('{{dateTimeShift days=2}}', {} as any);
 

--- a/test/template-parser.spec.ts
+++ b/test/template-parser.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import { TemplateParser } from '../src/libs/template-parser';
 import { format as dateFormat } from 'date-fns';
+import { TemplateParser } from '../src/libs/template-parser';
 
 describe('Template parser', () => {
   describe('Helper: concat', () => {
@@ -100,11 +100,8 @@ describe('Template parser', () => {
   });
 
   describe('Helper: dateTimeShift', () => {
-    it('Should return a date shifted the specified amount of days from now.', ()=>{
-      const parseResult = TemplateParser(
-        '{{dateTimeShift days=2}}',
-        {} as any
-      );
+    it('Should return a date shifted the specified amount of days from now.', () => {
+      const parseResult = TemplateParser('{{dateTimeShift days=2}}', {} as any);
 
       const date = new Date();
       date.setDate(date.getDate() + 2);
@@ -113,7 +110,7 @@ describe('Template parser', () => {
       expect(parseResult).to.match(new RegExp(dateString + '.*'));
     });
 
-    it('Should return a date shifted by the requested amount from a specified start date.', ()=>{
+    it('Should return a date shifted by the requested amount from a specified start date.', () => {
       const parseResult = TemplateParser(
         "{{dateTimeShift date='2021-02-01' days=2 months=4}}",
         {} as any
@@ -122,7 +119,7 @@ describe('Template parser', () => {
       expect(parseResult).to.match(/2021-06-03.*/);
     });
 
-    it('Should return a date shifted by the requested amount from the specified start date in the specified format.', ()=>{
+    it('Should return a date shifted by the requested amount from the specified start date in the specified format.', () => {
       const parseResult = TemplateParser(
         "{{dateTimeShift date='2021-02-01' format='yyyy-MM-dd' days=2 months=4}}",
         {} as any
@@ -131,7 +128,7 @@ describe('Template parser', () => {
       expect(parseResult).to.equals('2021-06-03');
     });
 
-    it('Should return a date time shifted by the requested amount from the specified start date in the specified format.', ()=>{
+    it('Should return a date time shifted by the requested amount from the specified start date in the specified format.', () => {
       const parseResult = TemplateParser(
         "{{dateTimeShift date='2021-02-01T10:45:00' format=\"yyyy-MM-dd'T'HH:mm:ss\" days=8 months=3 hours=1 minutes=2 seconds=3}}",
         {} as any

--- a/test/template-parser.spec.ts
+++ b/test/template-parser.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { TemplateParser } from '../src/libs/template-parser';
+import { format as dateFormat } from 'date-fns';
 
 describe('Template parser', () => {
   describe('Helper: concat', () => {
@@ -97,6 +98,48 @@ describe('Template parser', () => {
       expect(parseResult).to.be.equal('');
     });
   });
+
+  describe('Helper: dateTimeShift', () => {
+    it('Should return a date shifted the specified amount of days from now.', ()=>{
+      const parseResult = TemplateParser(
+        "{{dateTimeShift shiftDays=2}}",
+        {} as any
+      )
+
+      let date = new Date();
+      date.setDate(date.getDate() + 2);
+      // As our reference date here may differ slightly from the one interally used in the helper, it's more reliable to just compare the date/time with the seconds (and lower) excluded.
+      var dateString = dateFormat(date, "yyyy-MM-dd'T'HH:mm");
+      expect(parseResult).to.match(new RegExp(dateString + ".*"));
+    });
+
+    it('Should return a date shifted by the requested amount from a specified start date.', ()=>{
+      const parseResult = TemplateParser(
+        "{{dateTimeShift date='2021-02-01' shiftDays=2 shiftMonths=4}}",
+        {} as any
+      )
+
+      expect(parseResult).to.match(/2021-06-03.*/);
+    });
+
+    it('Should return a date shifted by the requested amount from the specified start date in the specified format.', ()=>{
+      const parseResult = TemplateParser(
+        "{{dateTimeShift date='2021-02-01' format='yyyy-MM-dd' shiftDays=2 shiftMonths=4}}",
+        {} as any
+      )
+
+      expect(parseResult).to.equals('2021-06-03');
+    });
+
+    it('Should return a date time shifted by the requested amount from the specified start date in the specified format.', ()=>{
+      const parseResult = TemplateParser(
+        "{{dateTimeShift date='2021-02-01T10:45:00' format=\"yyyy-MM-dd'T'HH:mm:ss\" shiftDays=8 shiftMonths=3 shiftHours=1 shiftMinutes=2 shiftSeconds=3}}",
+        {} as any
+      )
+
+      expect(parseResult).to.equals('2021-05-09T11:47:03');
+    });
+  })
 
   describe('Helper: someOf', () => {
     it('should return one element', () => {

--- a/test/template-parser.spec.ts
+++ b/test/template-parser.spec.ts
@@ -102,7 +102,7 @@ describe('Template parser', () => {
   describe('Helper: dateTimeShift', () => {
     it('Should return a date shifted the specified amount of days from now.', ()=>{
       const parseResult = TemplateParser(
-        '{{dateTimeShift shiftDays=2}}',
+        '{{dateTimeShift days=2}}',
         {} as any
       );
 
@@ -115,7 +115,7 @@ describe('Template parser', () => {
 
     it('Should return a date shifted by the requested amount from a specified start date.', ()=>{
       const parseResult = TemplateParser(
-        "{{dateTimeShift date='2021-02-01' shiftDays=2 shiftMonths=4}}",
+        "{{dateTimeShift date='2021-02-01' days=2 months=4}}",
         {} as any
       );
 
@@ -124,7 +124,7 @@ describe('Template parser', () => {
 
     it('Should return a date shifted by the requested amount from the specified start date in the specified format.', ()=>{
       const parseResult = TemplateParser(
-        "{{dateTimeShift date='2021-02-01' format='yyyy-MM-dd' shiftDays=2 shiftMonths=4}}",
+        "{{dateTimeShift date='2021-02-01' format='yyyy-MM-dd' days=2 months=4}}",
         {} as any
       );
 
@@ -133,7 +133,7 @@ describe('Template parser', () => {
 
     it('Should return a date time shifted by the requested amount from the specified start date in the specified format.', ()=>{
       const parseResult = TemplateParser(
-        "{{dateTimeShift date='2021-02-01T10:45:00' format=\"yyyy-MM-dd'T'HH:mm:ss\" shiftDays=8 shiftMonths=3 shiftHours=1 shiftMinutes=2 shiftSeconds=3}}",
+        "{{dateTimeShift date='2021-02-01T10:45:00' format=\"yyyy-MM-dd'T'HH:mm:ss\" days=8 months=3 hours=1 minutes=2 seconds=3}}",
         {} as any
       );
 


### PR DESCRIPTION
Closes https://github.com/mockoon/mockoon/issues/355

Implemented a combined dateTimeShift helper based on prior implementation by zelenovas.

I changed the parameters to use the options.hash map rather then passed in directly to allow the shift parameters to be passed optionally in any order. I also added the ability to set the initial reference date so it can come from a query string parameter or other variable rather than always being based on the current time.
