### PR TITLE
Body helper enhancement - Stringify

### DIFF
--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -80,11 +80,7 @@ const TemplateParserHelpers = function (request: Request) {
       return new SafeString(fakedContent);
     },
     // get json property from body
-    body: function (
-      path: string,
-      defaultValue: string,
-      stringify: boolean = false
-    ) {
+    body: function (path: string, defaultValue: string, stringify: boolean) {
       // no path provided
       if (typeof path === 'object') {
         path = '';
@@ -93,6 +89,11 @@ const TemplateParserHelpers = function (request: Request) {
       // no default value provided
       if (typeof defaultValue === 'object') {
         defaultValue = '';
+      }
+
+      // no value for stringify provided
+      if (typeof stringify === 'object') {
+        stringify = false;
       }
 
       // if no path has been provided we want the full raw body as is
@@ -109,18 +110,19 @@ const TemplateParserHelpers = function (request: Request) {
       }
 
       if (!requestToParse) {
-        return defaultValue;
+        return new SafeString(
+          stringify ? JSON.stringify(defaultValue) : defaultValue
+        );
       }
 
-      const value = objectGet(requestToParse, path);
+      let value = objectGet(requestToParse, path);
+      value = value === undefined ? defaultValue : value;
 
       if (Array.isArray(value) || typeof value === 'object') {
         stringify = true;
       }
 
-      return value !== undefined
-        ? new SafeString(stringify ? JSON.stringify(value) : value)
-        : defaultValue;
+      return new SafeString(stringify ? JSON.stringify(value) : value);
     },
     // use params from url /:param1/:param2
     urlParam: function (paramName: string) {

--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -112,7 +112,7 @@ const TemplateParserHelpers = function (request: Request) {
         return defaultValue;
       }
 
-      let value = objectGet(requestToParse, path);
+      const value = objectGet(requestToParse, path);
 
       if (Array.isArray(value) || typeof value === 'object') {
         stringify = true;

--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -80,7 +80,11 @@ const TemplateParserHelpers = function (request: Request) {
       return new SafeString(fakedContent);
     },
     // get json property from body
-    body: function (path: string, defaultValue: string) {
+    body: function (
+      path: string,
+      defaultValue: string,
+      stringify: boolean = false
+    ) {
       // no path provided
       if (typeof path === 'object') {
         path = '';
@@ -111,10 +115,12 @@ const TemplateParserHelpers = function (request: Request) {
       let value = objectGet(requestToParse, path);
 
       if (Array.isArray(value) || typeof value === 'object') {
-        value = JSON.stringify(value);
+        stringify = true;
       }
 
-      return value !== undefined ? new SafeString(value) : defaultValue;
+      return value !== undefined
+        ? new SafeString(stringify ? JSON.stringify(value) : value)
+        : defaultValue;
     },
     // use params from url /:param1/:param2
     urlParam: function (paramName: string) {

--- a/test/template-parser.spec.ts
+++ b/test/template-parser.spec.ts
@@ -212,4 +212,57 @@ describe('Template parser', () => {
       expect(parseResult).to.be.equal('dmFsdWU6IDEyMw==');
     });
   });
+
+  describe('Helper: body', () => {
+    it('should return number without quotes', () => {
+      const parseResult = TemplateParser("{{body 'prop1' undefined true}}", {
+        bodyJSON: { prop1: 1 }
+      } as any);
+      expect(parseResult).to.be.equal('1');
+    });
+
+    it('should return boolean value without quotes', () => {
+      const parseResult = TemplateParser("{{body 'prop1' undefined true}}", {
+        bodyJSON: { prop1: true }
+      } as any);
+      expect(parseResult).to.be.equal('true');
+    });
+
+    it('should return null value without quotes', () => {
+      const parseResult = TemplateParser("{{body 'prop1' undefined true}}", {
+        bodyJSON: { prop1: null }
+      } as any);
+      expect(parseResult).to.be.equal('null');
+    });
+
+    it('should always return array as JSON string', () => {
+      const parseResult = TemplateParser("{{body 'prop1' undefined false}}", {
+        bodyJSON: { prop1: ['first', 'second'] }
+      } as any);
+      expect(parseResult).to.be.equal('["first","second"]');
+    });
+
+    it('should always return object as JSON string', () => {
+      const parseResult = TemplateParser("{{body 'prop1' undefined false}}", {
+        bodyJSON: { prop1: { key: 'value' } }
+      } as any);
+      expect(parseResult).to.be.equal('{"key":"value"}');
+    });
+
+    it('should return string enclosed in quotes', () => {
+      const parseResult = TemplateParser("{{body 'prop1' undefined true}}", {
+        bodyJSON: { prop1: 'test' }
+      } as any);
+      expect(parseResult).to.be.equal('"test"');
+    });
+
+    it('should escape newlines and quotes in string', () => {
+      const parseResult = TemplateParser("{{body 'prop1' undefined true}}", {
+        bodyJSON: { prop1: 'This \n is a "message" with quotes.' }
+      } as any);
+      expect(parseResult).to.be.equal(
+        '"This \\n is a \\"message\\" with quotes."'
+      );
+    });
+  });
 });

--- a/test/template-parser.spec.ts
+++ b/test/template-parser.spec.ts
@@ -249,11 +249,25 @@ describe('Template parser', () => {
       expect(parseResult).to.be.equal('{"key":"value"}');
     });
 
+    it('should return default value enclosed in quotes', () => {
+      const parseResult = TemplateParser("{{body 'prop2' 'default' true}}", {
+        bodyJSON: { prop1: 'test' }
+      } as any);
+      expect(parseResult).to.be.equal('"default"');
+    });
+
     it('should return string enclosed in quotes', () => {
       const parseResult = TemplateParser("{{body 'prop1' undefined true}}", {
         bodyJSON: { prop1: 'test' }
       } as any);
       expect(parseResult).to.be.equal('"test"');
+    });
+
+    it('should not return string enclosed in quotes', () => {
+      const parseResult = TemplateParser("{{body 'prop1'}}", {
+        bodyJSON: { prop1: 'test' }
+      } as any);
+      expect(parseResult).to.be.equal('test');
     });
 
     it('should escape newlines and quotes in string', () => {


### PR DESCRIPTION
Adds a new parameter to the body helper.

If it is set to true and the value is a primitive, the helper returns the stringified version of the value.
This fixes an issue where string values where not correctly escaped when being returned by a body helper. The reason for going with an extra parameter here is to 1. ensure backwards compatibility and 2. still enable user to use the unescaped values as the input to other helpers like `concat`.

**Parent issue** 

Closes https://github.com/mockoon/mockoon/issues/397
(needs to be closed manually)

**Technical implementation details**
There is a third parameter for the body helper now. It is false by default and you can set the value by invoking it via `{{ body 'foo.bar' undefined true }}`. If the parameter is set to `true`, the value referenced by the path is processed by `JSON.stringify`before it is returned. If parameter is `false`, primitive values (i.e. null, integer, string, boolean) will not be processed by `JSON.stringify`. However, objects and arrays will always be stringified, no matter which value the user passes for the parameter.