### PR TITLE
Query param helper enhancement - Stringify

### DIFF
--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -121,7 +121,11 @@ const TemplateParserHelpers = function (request: Request) {
       return request.params[paramName];
     },
     // use params from query string ?param1=xxx&param2=yyy
-    queryParam: function (path: string, defaultValue: string) {
+    queryParam: function (
+      path: string,
+      defaultValue: string,
+      stringify: boolean = false
+    ) {
       // no path provided
       if (typeof path === 'object') {
         path = '';
@@ -141,13 +145,15 @@ const TemplateParserHelpers = function (request: Request) {
         return new SafeString(JSON.stringify(request.query));
       }
 
-      let value = objectGet(request.query, path);
+      const value = objectGet(request.query, path);
 
       if (Array.isArray(value) || typeof value === 'object') {
-        value = JSON.stringify(value);
+        stringify = true;
       }
 
-      return value !== undefined ? new SafeString(value) : defaultValue;
+      return value !== undefined
+        ? new SafeString(stringify ? JSON.stringify(value) : value)
+        : defaultValue;
     },
     // use content from request header
     header: function (headerName: string, defaultValue: string) {

--- a/src/libs/template-parser.ts
+++ b/src/libs/template-parser.ts
@@ -124,7 +124,7 @@ const TemplateParserHelpers = function (request: Request) {
     queryParam: function (
       path: string,
       defaultValue: string,
-      stringify: boolean = false
+      stringify: boolean
     ) {
       // no path provided
       if (typeof path === 'object') {
@@ -136,8 +136,15 @@ const TemplateParserHelpers = function (request: Request) {
         defaultValue = '';
       }
 
+      // no value for stringify provided
+      if (typeof stringify === 'object') {
+        stringify = false;
+      }
+
       if (!request.query) {
-        return defaultValue;
+        return new SafeString(
+          stringify ? JSON.stringify(defaultValue) : defaultValue
+        );
       }
 
       // if no path has been provided we want the full query string object as is
@@ -145,15 +152,14 @@ const TemplateParserHelpers = function (request: Request) {
         return new SafeString(JSON.stringify(request.query));
       }
 
-      const value = objectGet(request.query, path);
+      let value = objectGet(request.query, path);
+      value = value === undefined ? defaultValue : value;
 
       if (Array.isArray(value) || typeof value === 'object') {
         stringify = true;
       }
 
-      return value !== undefined
-        ? new SafeString(stringify ? JSON.stringify(value) : value)
-        : defaultValue;
+      return new SafeString(stringify ? JSON.stringify(value) : value);
     },
     // use content from request header
     header: function (headerName: string, defaultValue: string) {

--- a/test/template-parser.spec.ts
+++ b/test/template-parser.spec.ts
@@ -265,7 +265,7 @@ describe('Template parser', () => {
     });
 
     it('should not return string enclosed in quotes', () => {
-      const parseResult = TemplateParser("{{queryParam 'param1'}}", {
+      const parseResult = TemplateParser("{{queryParam 'param1' 'default'}}", {
         query: { param1: 'test' }
       } as any);
       expect(parseResult).to.be.equal('test');
@@ -279,6 +279,16 @@ describe('Template parser', () => {
         } as any
       );
       expect(parseResult).to.be.equal('"test"');
+    });
+
+    it('should return default value enclosed in quotes', () => {
+      const parseResult = TemplateParser(
+        "{{queryParam 'param1' 'default' true}}",
+        {
+          query: { param2: 'test' }
+        } as any
+      );
+      expect(parseResult).to.be.equal('"default"');
     });
 
     it('should escape quotes in string', () => {

--- a/test/template-parser.spec.ts
+++ b/test/template-parser.spec.ts
@@ -212,4 +212,83 @@ describe('Template parser', () => {
       expect(parseResult).to.be.equal('dmFsdWU6IDEyMw==');
     });
   });
+
+  describe('Helper: queryParam', () => {
+    it('should return number without quotes', () => {
+      const parseResult = TemplateParser(
+        "{{queryParam 'param1' undefined true}}",
+        {
+          query: { param1: 1 }
+        } as any
+      );
+      expect(parseResult).to.be.equal('1');
+    });
+
+    it('should return boolean value without quotes', () => {
+      const parseResult = TemplateParser(
+        "{{queryParam 'param1' undefined true}}",
+        {
+          query: { param1: true }
+        } as any
+      );
+      expect(parseResult).to.be.equal('true');
+    });
+
+    it('should return null value without quotes', () => {
+      const parseResult = TemplateParser(
+        "{{queryParam 'param1' undefined true}}",
+        {
+          query: { param1: null }
+        } as any
+      );
+      expect(parseResult).to.be.equal('null');
+    });
+
+    it('should always return array as JSON string', () => {
+      const parseResult = TemplateParser(
+        "{{queryParam 'param1' undefined false}}",
+        {
+          query: { param1: ['first', 'second'] }
+        } as any
+      );
+      expect(parseResult).to.be.equal('["first","second"]');
+    });
+
+    it('should always return object as JSON string', () => {
+      const parseResult = TemplateParser(
+        "{{queryParam 'param1' undefined false}}",
+        {
+          query: { param1: { key: 'value' } }
+        } as any
+      );
+      expect(parseResult).to.be.equal('{"key":"value"}');
+    });
+
+    it('should not return string enclosed in quotes', () => {
+      const parseResult = TemplateParser("{{queryParam 'param1'}}", {
+        query: { param1: 'test' }
+      } as any);
+      expect(parseResult).to.be.equal('test');
+    });
+
+    it('should return string enclosed in quotes', () => {
+      const parseResult = TemplateParser(
+        "{{queryParam 'param1' undefined true}}",
+        {
+          query: { param1: 'test' }
+        } as any
+      );
+      expect(parseResult).to.be.equal('"test"');
+    });
+
+    it('should escape quotes in string', () => {
+      const parseResult = TemplateParser(
+        "{{queryParam 'param1' undefined true}}",
+        {
+          query: { param1: 'This is a "message" with quotes.' }
+        } as any
+      );
+      expect(parseResult).to.be.equal('"This is a \\"message\\" with quotes."');
+    });
+  });
 });

--- a/test/template-parser.spec.ts
+++ b/test/template-parser.spec.ts
@@ -446,7 +446,7 @@ describe('Template parser', () => {
       expect(parseResult).to.be.equal('dmFsdWU6IDEyMw==');
     });
   });
-  
+
   describe('Helper: body', () => {
     it('should return number without quotes', () => {
       const parseResult = TemplateParser("{{body 'prop1' undefined true}}", {
@@ -513,7 +513,7 @@ describe('Template parser', () => {
       );
     });
   });
-  
+
   describe('Helper: queryParam', () => {
     it('should return number without quotes', () => {
       const parseResult = TemplateParser(


### PR DESCRIPTION
Added parameter to the queryParam helper.

If it is set to true and the value is a primitive, the helper returns the stringified version of the value.
This fixes an issue where invalid JSON was retuned if users wrapped the result of the helper in quotation marks but the query parameters were an array (see the issue for more details). The reason for going with an extra parameter here is to 1. ensure backwards compatibility and 2. still enable user to use the unescaped values as the input to other helpers like concat.

Parent issue

Closes https://github.com/mockoon/mockoon/issues/418
(needs to be closed manually)

Technical implementation details
There is a third parameter for the query helper now. It is false by default and you can set the value by invoking it via {{ queryParam 'foo.bar' undefined true }}. If the parameter is set to `true`, the value referenced by the path is processed by `JSON.stringify` before it is returned. If parameter is `false`, primitive values (i.e. null, integer, string, boolean) will not be processed by `JSON.stringify`. However, objects and arrays will always be stringified, no matter which value the user passes for the parameter.