### PR TITLE
Feature/empty fields rule check

### DIFF
--- a/src/constants/environment-schema.constants.ts
+++ b/src/constants/environment-schema.constants.ts
@@ -64,8 +64,7 @@ export const ResponseRuleDefault: ResponseRule = {
   target: 'body',
   modifier: '',
   value: '',
-  isRegex: false,
-  isEmpty: false
+  operator: 'equals'
 };
 
 export const HeaderDefault: Header = {
@@ -141,11 +140,9 @@ export const RouteSchema = Joi.object<Route>({
                 .allow('')
                 .failover(ResponseRuleDefault.value)
                 .required(),
-              isRegex: Joi.boolean()
-                .failover(ResponseRuleDefault.isRegex)
-                .required(),
-              isEmpty: Joi.boolean()
-                .failover(ResponseRuleDefault.isEmpty)
+              operator: Joi.string()
+                .valid('equals', 'regex', 'null', 'empty_array')
+                .failover(ResponseRuleDefault.operator)
                 .required()
             }),
             Joi.any().strip()

--- a/src/constants/environment-schema.constants.ts
+++ b/src/constants/environment-schema.constants.ts
@@ -64,7 +64,8 @@ export const ResponseRuleDefault: ResponseRule = {
   target: 'body',
   modifier: '',
   value: '',
-  isRegex: false
+  isRegex: false,
+  isEmpty: false
 };
 
 export const HeaderDefault: Header = {
@@ -142,6 +143,9 @@ export const RouteSchema = Joi.object<Route>({
                 .required(),
               isRegex: Joi.boolean()
                 .failover(ResponseRuleDefault.isRegex)
+                .required(),
+              isEmpty: Joi.boolean()
+                .failover(ResponseRuleDefault.isEmpty)
                 .required()
             }),
             Joi.any().strip()

--- a/src/libs/migrations.ts
+++ b/src/libs/migrations.ts
@@ -1,6 +1,12 @@
 import { v4 as uuid } from 'uuid';
 import { Environment } from '../models/environment.model';
-import { Header, Route, RouteResponse } from '../models/route.model';
+import {
+  Header,
+  ResponseRule,
+  Route,
+  RouteResponse
+} from '../models/route.model';
+import { ResponseRuleDefault } from '../constants/environment-schema.constants';
 
 /**
  * Old types use for compatibility purposes
@@ -334,6 +340,27 @@ export const Migrations: {
           if (routeResponse.fallbackTo404 === undefined) {
             routeResponse.fallbackTo404 = false;
           }
+        });
+      });
+    }
+  },
+  /**
+   * Replaced isRegex in Response Rules for operator field.
+   */
+  {
+    id: 18,
+    migrationFunction: (environment: Environment) => {
+      environment.routes.forEach((route: Route) => {
+        route.responses.forEach((routeResponse) => {
+          (routeResponse.rules as Array<ResponseRule & {isRegex?: boolean}>).forEach((rule) => {
+            if (rule.isRegex) {
+              rule.operator = 'regex';
+            }
+            if(rule.operator === undefined) {
+              rule.operator = ResponseRuleDefault.operator;
+            }
+            delete rule.isRegex;
+          });
         });
       });
     }

--- a/src/models/route.model.ts
+++ b/src/models/route.model.ts
@@ -15,12 +15,17 @@ export type RouteResponse = {
   fallbackTo404: boolean;
 };
 
+export type ResponseRuleOperators =
+  | 'equals'
+  | 'regex'
+  | 'null'
+  | 'empty_array';
+
 export type ResponseRule = {
   target: ResponseRuleTargets;
   modifier: string;
   value: string;
-  isRegex: boolean;
-  isEmpty: boolean;
+  operator: ResponseRuleOperators;
 };
 
 export type ResponseRuleTargets =

--- a/src/models/route.model.ts
+++ b/src/models/route.model.ts
@@ -20,6 +20,7 @@ export type ResponseRule = {
   modifier: string;
   value: string;
   isRegex: boolean;
+  isEmpty: boolean;
 };
 
 export type ResponseRuleTargets =


### PR DESCRIPTION
**Parent issue** 

Closes #[255]

**Technical implementation details**

A new Logic has been implemented for Response Rules which influences the way your fields or your values are checked. Until now there was only a checkbox for checking your value as regex. This is moved inside a dropdown where you can choose your validation method. For now the methods can be: equal (default), regex match (like the checkbox before), null (checks for undefined or null) and empty array (as name says).

